### PR TITLE
fixes for "run-script-os" and pyinstaller's "--onefile" issues, on linux

### DIFF
--- a/build-linux.spec
+++ b/build-linux.spec
@@ -1,34 +1,42 @@
-# -*- mode: python -*-
+# -*- mode: python ; coding: utf-8 -*-
 
 block_cipher = None
-
 added_files = [
     ('./gui', 'gui'),
 ]
 
 a = Analysis(['./src/index.py'],
              pathex=['./dist'],
-             binaries=None,
+             binaries=[],
              datas=added_files,
              hiddenimports=['clr'],
+             hookspath=[],
+             hooksconfig={},
+             runtime_hooks=[],
              excludes=[],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
              cipher=block_cipher)
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
 exe = EXE(pyz,
           a.scripts,
-          exclude_binaries=True,
-          name='pywebview-react-app',
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='pywebview-react',
           debug=False,
+          bootloader_ignore_signals=False,
           strip=True,
-          #icon='./src/assets/\logo.ico',
           upx=True,
-          console=False ) # set this to see error output of the executable
-coll = COLLECT(exe,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               strip=False,
-               upx=False,
-               name='pywebview-react-app')
+          upx_exclude=[],
+          #icon='./src/assets/logo.ico',
+          runtime_tmpdir=None,
+          console=False,
+          disable_windowed_traceback=False,
+          target_arch=None,
+          codesign_identity=None,
+          entitlements_file=None )

--- a/build-windows.spec
+++ b/build-windows.spec
@@ -1,34 +1,43 @@
-# -*- mode: python -*-
+# -*- mode: python ; coding: utf-8 -*-
+
 
 block_cipher = None
-
 added_files = [
     ('.\\gui', 'gui'),
 ]
 
 a = Analysis(['.\\src\\index.py'],
              pathex=['.\\dist'],
-             binaries=None,
+             binaries=[],
              datas=added_files,
              hiddenimports=['clr'],
+             hookspath=[],
+             hooksconfig={},
+             runtime_hooks=[],
              excludes=[],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
              cipher=block_cipher)
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
 exe = EXE(pyz,
           a.scripts,
-          exclude_binaries=True,
-          name='pywebview-react-app',
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='pywebview-react',
           debug=False,
-          strip=True,
-          icon='.\\src\\assets\\logo.ico',
+          bootloader_ignore_signals=False,
+          strip=False,
           upx=True,
-          console=False ) # set this to see error output of the executable
-coll = COLLECT(exe,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               strip=False,
-               upx=False,
-               name='pywebview-react-app')
+          upx_exclude=[],
+          icon='.\\src\\assets\\logo.ico',
+          runtime_tmpdir=None,
+          console=False,
+          disable_windowed_traceback=False,
+          target_arch=None,
+          codesign_identity=None,
+          entitlements_file=None )

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "npm run clean && npm run frontend:prod && run-script-os",
     "build:macos": "./venv-pywebview/bin/python build-macos.py py2app",
     "build:windows": ".\\venv-pywebview\\Scripts\\pyinstaller build-windows.spec",
-    "build:linux": "./venv-pywebview/bin/pyinstaller build-linux.spec --onefile",
+    "build:linux": "./venv-pywebview/bin/pyinstaller build-linux.spec",
     "clean": "run-script-os",
     "clean:default": "rm -rf dist 2>/dev/null; rm -rf gui 2>/dev/null; rm -rf build 2>/dev/null; ",
     "clean:windows": "if exist dist rd /S /Q dist & if exist build rd /S /Q build & if exist gui rd /S /Q gui",
@@ -41,13 +41,13 @@
   },
   "homepage": "https://github.com/r0x0r/pywebview-react-boilerplate#readme",
   "dependencies": {
-    "react": "16.12.0",
-    "react-dom": "16.12.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "parcel-bundler": "1.12.4",
-    "run-script-os": "1.0.7",
-    "sass": "1.25.0",
-    "typescript": "^3.7.5"
+    "parcel-bundler": "^1.12.5",
+    "run-script-os": "^1.1.6",
+    "sass": "^1.63.6",
+    "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
1. Bumped all dependencies, specifically "run-script-os" because of this issue(https://github.com/charlesguse/run-script-os/issues/42) in version 1.0.7.
2. Removed "--onefile" for linux since it throws error, instead updated spec files in order to create true standalone executable.
3. I only checked these changes in linux environment, and I have no idea if it will for windows and macos. Please report here if you have checked.